### PR TITLE
no need className='components-toolbar'

### DIFF
--- a/jsforwp-blocks/blocks/examples/05-custom-toolbar/index.js
+++ b/jsforwp-blocks/blocks/examples/05-custom-toolbar/index.js
@@ -68,7 +68,7 @@ export default registerBlockType(
                   		onChange={ ( value ) => props.setAttributes( { alignment: value } ) }
                   	/>
                     <Toolbar
-                      className='components-toolbar'
+                      
                     >
                       <Tooltip text={ __( 'High Contrast' )  }>
                         <Button


### PR DESCRIPTION
no need className='components-toolbar'  because Gutenberg by default setting no need components-toolbar Toolbar component.  if we manually  set className='components-toolbar' . we see double classes class="components-toolbar components-toolbar"